### PR TITLE
fix: Webpack rule for CSS

### DIFF
--- a/packages/fuselage/webpack.config.js
+++ b/packages/fuselage/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = (env, argv) => ({
         test: /\.scss$/,
         use: [
           {
-            loader: 'style-loader',
+            loader: 'style-loader/useable',
           },
           MiniCssExtractPlugin.loader,
           {


### PR DESCRIPTION
For some distraction `style-loader` was used instead of `style-loader/useable`.