### PR TITLE
fix: Bundle errors

### DIFF
--- a/packages/fuselage/src/components/Icon/index.js
+++ b/packages/fuselage/src/components/Icon/index.js
@@ -1,6 +1,6 @@
 import { useClassName } from '@rocket.chat/fuselage-hooks';
-import * as characters from '@rocket.chat/icons/dist/font/characters';
-import * as names from '@rocket.chat/icons/dist/font/index';
+import * as characters from '@rocket.chat/icons/dist/font/characters.js';
+import * as names from '@rocket.chat/icons/dist/font/index.js';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/packages/fuselage/webpack.config.js
+++ b/packages/fuselage/webpack.config.js
@@ -69,7 +69,7 @@ module.exports = (env, argv) => ({
       react: {
         commonjs: 'react',
         commonjs2: 'react',
-        amd: 'React',
+        amd: 'react',
         root: 'React',
       },
     },

--- a/packages/fuselage/webpack.config.js
+++ b/packages/fuselage/webpack.config.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
 module.exports = (env, argv) => ({
@@ -38,10 +37,7 @@ module.exports = (env, argv) => ({
       {
         test: /\.scss$/,
         use: [
-          {
-            loader: 'style-loader/useable',
-          },
-          MiniCssExtractPlugin.loader,
+          'style-loader/useable',
           {
             loader: 'css-loader',
             options: {
@@ -83,9 +79,6 @@ module.exports = (env, argv) => ({
       generateStatsFile: false,
       reportFilename: '../bundle-report.html',
       openAnalyzer: false,
-    }),
-    new MiniCssExtractPlugin({
-      filename: '[name].css',
     }),
   ],
 });


### PR DESCRIPTION
1. `React` was declared as an external AMD dependency instead of `react`;
2. Some build systems prefer `.mjs` over `.js` without proper parsing;
3. `MiniCssExtractPlugin.loader` cannot be used with `'style-loader'` in the same chain (see https://github.com/webpack-contrib/mini-css-extract-plugin#advanced-configuration-example)