### PR TITLE
fix: Change bundle format of fuselage-hooks

### DIFF
--- a/packages/fuselage-hooks/rollup.config.js
+++ b/packages/fuselage-hooks/rollup.config.js
@@ -10,9 +10,9 @@ export default {
   output: [
     {
       file: pkg.main,
-      format: 'es',
-      sourcemap: true
-    }
+      format: 'cjs',
+      sourcemap: true,
+    },
   ],
   plugins: [
     external(),


### PR DESCRIPTION
Meteor doesn't handle ES modules yet...