### PR TITLE
fix: useDebouncedCallback deps

### DIFF
--- a/packages/fuselage-hooks/src/useDebouncedCallback.js
+++ b/packages/fuselage-hooks/src/useDebouncedCallback.js
@@ -11,4 +11,4 @@ import { debounce } from './helpers';
  * @return {function} a memoized and debounced callback
  */
 export const useDebouncedCallback = (callback, delay, deps) =>
-  useMemo(() => debounce(callback, delay), Array.isArray(deps) ? [callback, delay, ...deps] : undefined);
+  useMemo(() => debounce(callback, delay), Array.isArray(deps) ? [delay, ...deps] : undefined);


### PR DESCRIPTION
As `useCallback`, `useDebouncedCallback` hook should ignore `callback` parameter changes to be memoized.