### PR TITLE
fix: Explicitly remove box-shadow for InputBox in Firefox

### DIFF
--- a/packages/fuselage/src/components/InputControl/styles.js
+++ b/packages/fuselage/src/components/InputControl/styles.js
@@ -17,6 +17,7 @@ export const withDecoratorColors = ({
 }) => css`
   background-color: ${ backgroundColor };
   border-color: ${ borderColor };
+  box-shadow: none;
 
   &:hover,
   &.hover {


### PR DESCRIPTION
The user-agent stylesheet of Firefox adds a red shadow to invalid inputs.