### PR TITLE
chore: Don't minify CSS on Storybook

### DIFF
--- a/packages/fuselage/.storybook/webpack.config.js
+++ b/packages/fuselage/.storybook/webpack.config.js
@@ -28,7 +28,6 @@ module.exports = async ({ config, mode }) => {
             require('postcss-custom-properties')(),
             require('postcss-logical')({ preserve: true }),
             require('autoprefixer')(),
-            require('cssnano'),
           ],
         },
       },


### PR DESCRIPTION
Remove `cssnano` on PostCSS for Storybook to increase CSS readability for debugging.