### PR TITLE
fix: Replace eval-based source maps

### DIFF
--- a/packages/fuselage-ui-kit/webpack.config.js
+++ b/packages/fuselage-ui-kit/webpack.config.js
@@ -3,9 +3,6 @@
 const path = require('path');
 
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const ReplacePlugin = require('webpack-plugin-replace');
-
-const pkg = require('./package.json');
 
 module.exports = (env, argv) => ({
   entry: {
@@ -18,7 +15,7 @@ module.exports = (env, argv) => ({
     libraryTarget: 'umd',
     umdNamedDefine: true,
   },
-  devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
+  devtool: argv.mode === 'production' ? false : 'source-map',
   module: {
     rules: [
       // {

--- a/packages/fuselage/webpack.config.js
+++ b/packages/fuselage/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = (env, { mode = 'production' }) => ({
     libraryTarget: 'umd',
     umdNamedDefine: true,
   },
-  devtool: mode === 'production' ? false : 'eval-source-map',
+  devtool: mode === 'production' ? false : 'source-map',
   module: {
     rules: [
       {

--- a/packages/ui-kit/webpack.config.js
+++ b/packages/ui-kit/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = (env, argv) => ({
     libraryTarget: 'umd',
     umdNamedDefine: true,
   },
-  devtool: argv.mode === 'production' ? 'source-map' : 'eval-source-map',
+  devtool: argv.mode === 'production' ? false : 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
Under restricted CSP, `eval()` calls are forbidden. This PR removes source maps from production builds and adds regular ones to development builds.