### PR TITLE
feat: Added callback prop for scroll position

### DIFF
--- a/packages/fuselage/src/components/Box/Scrollable/index.js
+++ b/packages/fuselage/src/components/Box/Scrollable/index.js
@@ -1,9 +1,24 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { useProps } from '../../../hooks';
 
-export function Scrollable({ children, horizontal, vertical, smooth }) {
+export function Scrollable({ children, horizontal, vertical, smooth, scrollCb }) {
+  let scrollTimeout;
+
+  const handleScroll = useCallback(function(event) {
+    const { target } = event;
+    if (!scrollTimeout) {
+      scrollCb({ top: !!target.scrollTop, bottom: !!(target.scrollTop + target.clientHeight - target.scrollHeight), left: !!target.scrollLeft, right: !!(target.scrollLeft + target.clientWidth - target.scrollWidth) });
+    } else {
+      clearTimeout(scrollTimeout);
+    }
+    scrollTimeout = setTimeout(() => {
+      scrollTimeout = false;
+      scrollCb({ top: !!target.scrollTop, bottom: !!(target.scrollTop + target.clientHeight - target.scrollHeight), left: !!target.scrollLeft, right: !!(target.scrollLeft + target.clientWidth - target.scrollWidth) });
+    }, 200);
+  }, [scrollCb]);
+
   const [, PropsProvider] = useProps(({ className, ...props }) => ({
     className: [
       className,
@@ -12,6 +27,7 @@ export function Scrollable({ children, horizontal, vertical, smooth }) {
       vertical && 'rcx-box--scrollable-vertical',
       smooth && 'rcx-box--scrollable-smooth',
     ].filter(Boolean).join(' '),
+    onScroll: typeof scrollCb !== 'undefined' ? handleScroll : null,
     ...props,
   }), [horizontal, vertical, smooth]);
 
@@ -22,4 +38,5 @@ Scrollable.propTypes = {
   horizontal: PropTypes.bool,
   vertical: PropTypes.bool,
   smooth: PropTypes.bool,
+  scrollCb: PropTypes.func,
 };

--- a/packages/fuselage/src/components/Box/Scrollable/index.js
+++ b/packages/fuselage/src/components/Box/Scrollable/index.js
@@ -27,7 +27,7 @@ export function Scrollable({ children, horizontal, vertical, smooth, onScrollCon
       vertical && 'rcx-box--scrollable-vertical',
       smooth && 'rcx-box--scrollable-smooth',
     ].filter(Boolean).join(' '),
-    onScroll: typeof onScrollContent !== 'undefined' ? handleScroll : null,
+    onScroll: typeof onScrollContent !== 'undefined' ? handleScroll : undefined,
     ...props,
   }), [horizontal, vertical, smooth]);
 


### PR DESCRIPTION
Scrollable now accepts scrollCb that receives `{ top: bool, bottom: bool, left: bool, right: bool}`.

The condition for each boolean is that content is hidden in that direction (eg. if scrolled down, top will be true).