### PR TITLE
fix: Build @rocket.chat/css-in-js as ES module

### DIFF
--- a/packages/css-in-js/package.json
+++ b/packages/css-in-js/package.json
@@ -20,6 +20,7 @@
     "css-in-js"
   ],
   "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "files": [
     "dist"
   ],

--- a/packages/css-in-js/rollup.config.js
+++ b/packages/css-in-js/rollup.config.js
@@ -13,6 +13,11 @@ export default {
       format: 'cjs',
       sourcemap: true,
     },
+    {
+      file: pkg.module,
+      format: 'esm',
+      sourcemap: true,
+    },
   ],
   plugins: [
     external(),

--- a/packages/fuselage/package.json
+++ b/packages/fuselage/package.json
@@ -120,8 +120,6 @@
     }
   },
   "dependencies": {
-    "@emotion/hash": "^0.8.0",
-    "@emotion/stylis": "^0.8.5",
     "@rocket.chat/css-in-js": "^0.4.0",
     "@rocket.chat/fuselage-tokens": "^0.4.0",
     "@rocket.chat/icons": "^0.4.0"


### PR DESCRIPTION
For some reason Webpack throws warnings about ignoring CommonJS exports. This seems to fix it.