### PR TITLE
fix: lamejs problematic usage

### DIFF
--- a/packages/mp3-encoder/package.json
+++ b/packages/mp3-encoder/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "lamejs": "^1.2.0"
+    "lamejs": "https://github.com/zhuker/lamejs"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",

--- a/packages/mp3-encoder/rollup.config.js
+++ b/packages/mp3-encoder/rollup.config.js
@@ -15,6 +15,7 @@ export default [
       entryFileNames: path.basename(pkg.main),
       format: 'cjs',
       sourcemap: true,
+      strict: false,
     },
     plugins: [
       external(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11321,10 +11321,9 @@ known-css-properties@^0.18.0:
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.18.0.tgz#d6e00b56ee1d5b0d171fd86df1583cfb012c521f"
   integrity sha512-69AgJ1rQa7VvUsd2kpvVq+VeObDuo3zrj0CzM5Slmf6yduQFAI2kXPDQJR2IE/u6MSAUOJrwSzjg5vlz8qcMiw==
 
-lamejs@^1.2.0:
+"lamejs@https://github.com/zhuker/lamejs":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/lamejs/-/lamejs-1.2.0.tgz#0259f83db4666141a7b671b8caa6369d95177d08"
-  integrity sha1-Aln4PbRmYUGntnG4yqY2nZUXfQg=
+  resolved "https://github.com/zhuker/lamejs#564612b5b57336238a5920ba4c301b49f7cb2bab"
   dependencies:
     use-strict "1.0.1"
 


### PR DESCRIPTION
The `lamejs` isn't published in npmjs.com since 2017 and it wasn't bundled for modular use. As result, our package was presenting the same issues reported in https://github.com/RocketChat/Rocket.Chat/issues/10530 (thanks @rkramer1964 for [solution](https://github.com/RocketChat/Rocket.Chat/issues/10530#issuecomment-462843092)). We should replace it in the future with the MediaRecorder API.