### PR TITLE
fix: useMediaQueries support on Safari and IE11

### DIFF
--- a/packages/fuselage-hooks/src/useMediaQueries.ts
+++ b/packages/fuselage-hooks/src/useMediaQueries.ts
@@ -33,12 +33,22 @@ export const useMediaQueries = (...queries: string[]): boolean[] => {
       },
       subscribe: (cb: () => void) => {
         mediaQueryLists.forEach((mediaQueryList) => {
-          mediaQueryList.addEventListener('change', cb);
+          if (typeof mediaQueryList.addEventListener === 'function') {
+            mediaQueryList.addEventListener('change', cb);
+            return;
+          }
+
+          mediaQueryList.addListener(cb);
         });
 
         return () => {
           mediaQueryLists.forEach((mediaQueryList) => {
-            mediaQueryList.removeEventListener('change', cb);
+            if (typeof mediaQueryList.removeEventListener === 'function') {
+              mediaQueryList.removeEventListener('change', cb);
+              return;
+            }
+
+            mediaQueryList.removeListener(cb);
           });
         };
       },


### PR DESCRIPTION
As seen in https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener:

> This is basically an alias for EventTarget.addEventListener(), for backwards compatibility purposes. Older browsers should use addListener instead of addEventListener since MediaQueryList only inherits from EventTarget in newer browsers.

`MediaQueryList` don't inherits from `EventTarget` in [Safari and IE11](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Browser_compatibility). This PR fallbacks to `addListener`/`removeListener` when `addEventListener`/`removeEventListener` aren't present.