### PR TITLE
fix: Disable :focus-visible for the time being

### DIFF
--- a/packages/fuselage/src/styles/mixins/states.scss
+++ b/packages/fuselage/src/styles/mixins/states.scss
@@ -24,9 +24,10 @@
 }
 
 @mixin on-focus-visible {
-  &:focus-visible {
-    @content;
-  }
+  // TODO: reenable this, :focus-visible is crashing the other selectors of this mixin when in production
+  // &:focus-visible {
+  //   @content;
+  // }
 
   @at-root .js-focus-visible &:focus.focus-visible, .js-focus-visible &.focus.focus-visible {
     @content;


### PR DESCRIPTION
The :focus-visible selector has been causing some problems and in an effort to keep usability, it'll be disabled 'till we review this.