### PR TITLE
fix: Flex-shrink on fields

### DIFF
--- a/packages/fuselage/src/components/Field/styles.scss
+++ b/packages/fuselage/src/components/Field/styles.scss
@@ -6,6 +6,7 @@
   display: flex;
   flex-flow: column nowrap;
   align-items: stretch;
+  flex-shrink: 0;
 
   width: 100%;
   margin-block: lengths.margin(-2);


### PR DESCRIPTION
This was breaking the fields on safari

Companion PR of https://github.com/RocketChat/Rocket.Chat/pull/19671
