### PR TITLE
fix: Sidebar menu cropped in extended mode

### DIFF
--- a/packages/fuselage/src/components/Sidebar/styles.scss
+++ b/packages/fuselage/src/components/Sidebar/styles.scss
@@ -185,7 +185,7 @@ $sidebar-item-color-selected: theme(
 
     &:hover &__menu-wraper,
     &.focus-within &__menu-wraper {
-      position: relative;
+      position: static;
 
       width: lengths.size(20);
       margin-inline: lengths.margin(4);
@@ -208,6 +208,8 @@ $sidebar-item-color-selected: theme(
     }
 
     &__menu-wraper {
+      position: relative;
+
       flex-shrink: 0;
 
       width: 0;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40830821/108430314-f3840400-721f-11eb-91e3-33aad0cf3353.png)

After:
![image](https://user-images.githubusercontent.com/40830821/108430350-04347a00-7220-11eb-9b19-e188c40924c3.png)
