### PR TITLE
feat: usePrevious hook

### DIFF
--- a/packages/fuselage-hooks/src/index.ts
+++ b/packages/fuselage-hooks/src/index.ts
@@ -16,6 +16,7 @@ export * from './usePosition';
 export * from './usePrefersColorScheme';
 export * from './usePrefersReducedData';
 export * from './usePrefersReducedMotion';
+export * from './usePrevious';
 export * from './useResizeObserver';
 export * from './useSafely';
 export * from './useStableArray';

--- a/packages/fuselage-hooks/src/usePrevious.spec.ts
+++ b/packages/fuselage-hooks/src/usePrevious.spec.ts
@@ -1,0 +1,43 @@
+import { FunctionComponent, createElement, StrictMode, useState } from 'react';
+import { render } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+import { usePrevious } from '.';
+
+it('returns previous values', () => {
+  let previous: number | undefined;
+  let current: number;
+  let increment: () => void;
+
+  const TestComponent: FunctionComponent = () => {
+    const [count, setCount] = useState(0);
+    previous = usePrevious(count);
+
+    current = count;
+    increment = () => {
+      setCount((count) => count + 1);
+    };
+
+    return null;
+  };
+
+  act(() => {
+    render(
+      createElement(StrictMode, {}, createElement(TestComponent)),
+      document.createElement('div')
+    );
+  });
+
+  expect(current).toBe(0);
+  expect(previous).toBe(undefined);
+
+  act(increment);
+
+  expect(current).toBe(1);
+  expect(previous).toBe(0);
+
+  act(increment);
+
+  expect(current).toBe(2);
+  expect(previous).toBe(1);
+});

--- a/packages/fuselage-hooks/src/usePrevious.ts
+++ b/packages/fuselage-hooks/src/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  });
+
+  return ref.current;
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  new: For new features
  improve: For an improvement (performance or little improvements) in existing features
  fix: For bug fixes that affects the end user
  break: For pull requests including breaking changes
  chore: For small tasks
  doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the Contributing Guide
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have labeled the PR correctly with the related package
- [ ] I have run Loki's visual regression tests (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->
`usePrevious()` might be useful as a complement for effects where you need to track _how_ a value have changed.
<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
