### PR TITLE
fix(fuselage-hooks): useContentBoxSize and useBorderBoxSize crashing in safari

### DIFF
--- a/packages/fuselage-hooks/src/extractSizeFromObserver.ts
+++ b/packages/fuselage-hooks/src/extractSizeFromObserver.ts
@@ -1,0 +1,39 @@
+type ObserverSizeProperty = 'contentBoxSize' | 'borderBoxSize';
+
+export const extractSizeFromObserver = (
+  entry: ResizeObserverEntry,
+  sizeProperty: ObserverSizeProperty
+): ResizeObserverSize => {
+  // In case we're dealing with Safari, 'contentBoxSize'
+  // && 'borderBoxSize' do not exist up to this point.
+  // 'contentRect' does exist though, and per definition, it's
+  // height and width are equivalent to 'contentBoxSize'
+  if (!entry[sizeProperty]) {
+    if (sizeProperty === 'contentBoxSize') {
+      return {
+        inlineSize: entry.contentRect.width,
+        blockSize: entry.contentRect.height,
+      };
+    }
+
+    return {
+      inlineSize: Math.round(entry.target.getBoundingClientRect().width),
+      blockSize: Math.round(entry.target.getBoundingClientRect().height),
+    };
+  }
+
+  // entry[sizeProperty] has to be assigned to a const so
+  // that TS inference works properly.
+  const entrySizeProperty = entry[sizeProperty];
+
+  // Some browsers (FF) do not return the property as an
+  // array, hence this check.
+  const size = Array.isArray(entrySizeProperty)
+    ? entrySizeProperty[0]
+    : entrySizeProperty;
+
+  return {
+    blockSize: size.blockSize,
+    inlineSize: size.inlineSize,
+  };
+};

--- a/packages/fuselage-hooks/src/useBorderBoxSize.ts
+++ b/packages/fuselage-hooks/src/useBorderBoxSize.ts
@@ -1,5 +1,6 @@
 import { RefObject, useState } from 'react';
 
+import { extractSizeFromObserver } from './extractSizeFromObserver';
 import { useDebouncedCallback } from './useDebouncedCallback';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
@@ -34,11 +35,10 @@ export const useBorderBoxSize = (
         return;
       }
 
-      const borderBoxSize: ResizeObserverSize = Array.isArray(
-        entries[0].borderBoxSize
-      )
-        ? entries[0].borderBoxSize[0]
-        : entries[0].borderBoxSize;
+      const borderBoxSize = extractSizeFromObserver(
+        entries[0],
+        'borderBoxSize'
+      );
 
       setSizeWithDebounce((prevSize) => {
         if (

--- a/packages/fuselage-hooks/src/useContentBoxSize.ts
+++ b/packages/fuselage-hooks/src/useContentBoxSize.ts
@@ -1,5 +1,6 @@
 import { RefObject, useState } from 'react';
 
+import { extractSizeFromObserver } from './extractSizeFromObserver';
 import { useDebouncedCallback } from './useDebouncedCallback';
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
@@ -34,11 +35,10 @@ export const useContentBoxSize = (
         return;
       }
 
-      const contentBoxSize: ResizeObserverSize = Array.isArray(
-        entries[0].contentBoxSize
-      )
-        ? entries[0].contentBoxSize[0]
-        : entries[0].contentBoxSize;
+      const contentBoxSize = extractSizeFromObserver(
+        entries[0],
+        'contentBoxSize'
+      );
 
       setSizeWithDebounce((prevSize) => {
         if (

--- a/packages/fuselage-hooks/src/useResizeObserver.ts
+++ b/packages/fuselage-hooks/src/useResizeObserver.ts
@@ -1,5 +1,6 @@
 import { useRef, useEffect, RefObject } from 'react';
 
+import { extractSizeFromObserver } from './extractSizeFromObserver';
 import { useDebouncedState } from './useDebouncedState';
 
 /**
@@ -43,35 +44,9 @@ export const useResizeObserver = <T extends Element>({
 
   useEffect(() => {
     const observer = new ResizeObserver(([entry]) => {
-      const { contentBoxSize, borderBoxSize }: any = entry;
-
-      if (contentBoxSize && borderBoxSize) {
-        setSizes({
-          contentBoxSize: Array.isArray(contentBoxSize)
-            ? contentBoxSize[0]
-            : contentBoxSize,
-          borderBoxSize: Array.isArray(borderBoxSize)
-            ? borderBoxSize[0]
-            : borderBoxSize,
-        });
-        return;
-      }
-
-      const { target, contentRect } = entry;
-      const { width: contentBoxInlineSize, height: contentBoxBlockSize } =
-        contentRect;
-      const { width: borderBoxInlineSize, height: borderBoxBlockSize } =
-        target.getBoundingClientRect();
-
       setSizes({
-        contentBoxSize: {
-          inlineSize: contentBoxInlineSize,
-          blockSize: contentBoxBlockSize,
-        },
-        borderBoxSize: {
-          inlineSize: borderBoxInlineSize,
-          blockSize: borderBoxBlockSize,
-        },
+        contentBoxSize: extractSizeFromObserver(entry, 'contentBoxSize'),
+        borderBoxSize: extractSizeFromObserver(entry, 'borderBoxSize'),
       });
     });
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  improve: For an improvement (performance or little improvements) in existing features
  fix: For bug fixes that affects the end user
  chore: For small tasks
  docs: For documentation only changes
  perf: For code change that improves performance
  build: For changes that affect the build system or external dependencies
  ci: For changes to our CI configuration files and scripts
  refactor: For changes that neither fixes a bug nor adds a feature
  test: For adding missing tests or correcting existing tests

  E.g.:

  feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the Contributing Guide
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have labeled the PR correctly with the related package
- [ ] I have run Loki's visual regression tests (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)

<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->

## Issue(s)

<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
