### PR TITLE
fix(fuselage): CodeSnippet word-break

### DIFF
--- a/packages/fuselage/src/components/CodeSnippet/styles.scss
+++ b/packages/fuselage/src/components/CodeSnippet/styles.scss
@@ -18,5 +18,6 @@
 
   &__codebox {
     white-space: pre-line;
+    word-break: break-all;
   }
 }

--- a/packages/fuselage/src/components/CodeSnippet/styles.scss
+++ b/packages/fuselage/src/components/CodeSnippet/styles.scss
@@ -17,6 +17,8 @@
   background-color: colors.neutral(300);
 
   &__codebox {
+    margin-right: lengths.margin(8);
+
     white-space: pre-line;
     word-break: break-all;
   }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: For new features
  improve: For an improvement (performance or little improvements) in existing features
  fix: For bug fixes that affects the end user
  chore: For small tasks
  docs: For documentation only changes

  E.g.: feat(fuselage-hooks): Add useWhatever hook
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- Lint and unit tests pass locally with my changes
- I have labeled the PR correctly with the related package
- I have run visual regression tests (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
- I have added necessary documentation (if applicable)
- Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
- Added a word-break property to the codebox class;
- Added margin-right property to the codebox class;
The codebox class div was breaking with big words in small screens
![example](https://user-images.githubusercontent.com/41977327/152223797-8c01a7c6-5a31-4e41-89bf-5ab425898d95.png)

