### PR TITLE
fix(fuselage): Pinned Attachment Message White space fix

### DIFF
--- a/packages/fuselage/src/components/Message/Messages.styles.scss
+++ b/packages/fuselage/src/components/Message/Messages.styles.scss
@@ -251,4 +251,8 @@ $message-background-color-highlight: functions.theme(
       @include size.square(lengths.size(44));
     }
   }
+
+  &-attachment {
+    white-space: normal;
+  }
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  [NEW] For new features
  [IMPROVE] For an improvement (performance or little improvements) in existing features
  [FIX] For bug fixes that affect the end-user
  [BREAK] For pull requests including breaking changes
  Chore: For small tasks
  Doc: For documentation
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!-- CHANGELOG -->
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description will appear in the release notes if we accept the contribution.
-->

<!-- END CHANGELOG -->
It was added a CSS property to fix white-space styling to the Fuselage package and was added a new property called variant to the function that renders the `MarkdownText`component ([Pull Request here](https://github.com/RocketChat/Rocket.Chat/pull/25535))

![image](https://user-images.githubusercontent.com/20212776/168844060-01f8b1b0-7eba-40d3-954f-2c2d4d26b302.png)


## Issue(s)
Pinned messages cutting off information

![image](https://user-images.githubusercontent.com/20212776/168842779-182b5b7e-c448-4561-a761-2e045341b4b7.png)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Log in to the [rocket.chat](http://rocket.chat/)
2. Open a room
3. Pin some message


## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
